### PR TITLE
Handle all 24 OPC-N3 histogram bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The library automatically transfers all measurements to InfluxDB via WiFi connec
 - **Detailed Data Parsing**: Reads and parses the full histogram dataset, including:
     - PM1, PM2.5, and PM10 mass concentrations (in µg/m³).
     - Temperature (in °C) and Relative Humidity (in %RH).
-    - Particle counts for 16 distinct size bins.
+    - Particle counts for 24 distinct size bins.
     - Particle size boundaries for each bin (in µm).
     - Actual sampling period and sample flow rate.
     - Status information like laser status and reject counts.
@@ -83,7 +83,7 @@ This struct holds all the values read from the sensor.
 
 | Member                  | Type           | Description                                                              |
 | :---------------------- | :------------- | :----------------------------------------------------------------------- |
-| `bin_counts[16]`        | `uint16_t`     | Array containing the particle counts for each of the 16 main bins.       |
+| `bin_counts[24]`        | `uint16_t`     | Array containing the particle counts for each of the 24 histogram bins. |
 | `bin_boundaries_um[25]` | `float`        | Array of particle diameters (in µm) defining the edges of the 24 bins.   |
 | `pm_a`                  | `float`        | Mass concentration for PM size A (typically PM1) in µg/m³.               |
 | `pm_b`                  | `float`        | Mass concentration for PM size B (typically PM2.5) in µg/m³.             |
@@ -148,7 +148,7 @@ distribution. The table below lists the approximate diameter range for each bin.
 ## InfluxDB Integration
 The example project writes all sensor data directly to an InfluxDB instance.
 In addition to the PM values and environmental measurements, the individual
-particle bin counts are stored as separate fields (`bin_00` to `bin_15`). This
+particle bin counts are stored as separate fields (`bin_00` to `bin_23`). This
 allows detailed analysis and visualization of the histogram data in tools like
 Grafana.
 

--- a/src/OpcN3.cpp
+++ b/src/OpcN3.cpp
@@ -188,7 +188,8 @@ bool OpcN3::readData(OpcN3Data &data)
     }
 
     // Parse data from buffer
-    for (int i = 0; i < 16; i++)
+    // Read all 24 histogram bins
+    for (int i = 0; i < 24; i++)
         data.bin_counts[i] = combine_bytes(buffer[i * 2], buffer[i * 2 + 1]);
     data.bin1_mtof = buffer[48];
     data.bin3_mtof = buffer[49];

--- a/src/OpcN3.h
+++ b/src/OpcN3.h
@@ -8,7 +8,8 @@
 struct OpcN3Data
 {
     // Histogram Data
-    uint16_t bin_counts[16];
+    // The OPC-N3 reports 24 histogram bins
+    uint16_t bin_counts[24];
     float bin_boundaries_um[25];
 
     // MToF (Time-of-Flight for specific bins)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,7 +128,7 @@ void loop()
 
       // Print the individual bin counts with their size ranges
       Serial.println("\nParticle Size Bin Counts:");
-      for (int i = 0; i < 16; i++)
+      for (int i = 0; i < 24; i++)
       {
         Serial.printf("  Bin %2d (%.2f - %.2f um): %u counts\n",
                       i,
@@ -146,7 +146,7 @@ void loop()
       sensorPoint.addField("humidity", sensorData.humidity_rh);
 
       // Add individual bin counts as separate fields for detailed analysis
-      for (int i = 0; i < 16; i++)
+      for (int i = 0; i < 24; i++)
       {
         char fieldName[8];
         snprintf(fieldName, sizeof(fieldName), "bin_%02d", i);


### PR DESCRIPTION
## Summary
- update examples and documentation for 24 bins
- store 24 histogram bins in `OpcN3Data`
- parse all 24 bins in the driver
- send all bins to InfluxDB

## Testing
- `pio run` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_684c1132d988833298558109c945c8c1