### PR TITLE
Add CO2-only firmware variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ Getting started with this library is straightforward:
 1. Copy `include/config.h.example` to `include/config.h` and update it with your WiFi and InfluxDB credentials
    (you can also adjust `SENSOR_SLEEP_MS` here to set the non-blocking interval
    between readings)
-2. Flash the code to your ESP32
-3. The device will:
+2. Choose the firmware variant:
+   - `esp32dev` builds the full OPC-N3 and SCD41 firmware located in `src/`.
+   - `co2only` builds the CO₂-only firmware found in `src_co2/`.
+3. Flash the code to your ESP32
+4. The device will:
     - Automatically connect to your WiFi network
-    - Initialize the OPC-N3 sensor
+    - Initialize the OPC-N3 sensor (not used in the `co2only` build)
     - Initialize the SCD41 sensor and start periodic measurements
     - Start continuous measurements
     - Push all data directly to your InfluxDB instance

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,9 +1,9 @@
 ; PlatformIO Project Configuration File
 ;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
+; Build options: build flags, source filter
+; Upload options: custom upload port, speed and extra flags
+; Library options: dependencies, extra library storages
+; Advanced options: extra scripting
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
@@ -17,3 +17,7 @@ lib_deps =
         wifi
         tobiasschuerg/ESP8266 Influxdb@^3.13.2
         sensirion/Sensirion I2C SCD4x@^1.0.0
+
+[env:co2only]
+extends = env:esp32dev
+src_dir = src_co2

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,4 +20,5 @@ lib_deps =
 
 [env:co2only]
 extends = env:esp32dev
-src_dir = src_co2
+# Only compile sources from the src_co2 folder located at project root
+src_filter = +<../src_co2> -<*>

--- a/src_co2/main.cpp
+++ b/src_co2/main.cpp
@@ -1,0 +1,117 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <Wire.h>
+#include <SensirionI2cScd4x.h>
+#include <InfluxDbClient.h>
+#include <InfluxDbCloud.h>
+#include "config.h"
+
+const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
+
+SensirionI2cScd4x scd4x;
+
+#if defined(ESP32)
+#define DEVICE "ESP32"
+#else
+#define DEVICE "ARDUINO"
+#endif
+
+InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
+Point sensorPoint("scd41");
+
+void setup()
+{
+    Serial.begin(115200);
+    while (!Serial)
+        ;
+    Serial.println("\n\nSCD41 CO2 Reader");
+
+    Serial.printf("Connecting to WiFi '%s'", WIFI_SSID);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        Serial.print(".");
+        delay(500);
+    }
+    Serial.println(" connected");
+
+    timeSync(TZ_INFO, "pool.ntp.org", "time.nis.gov");
+
+    client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::S));
+    sensorPoint.addTag("device", DEVICE);
+    sensorPoint.addTag("ssid", WiFi.SSID());
+
+    if (client.validateConnection())
+    {
+        Serial.print("Connected to InfluxDB: ");
+        Serial.println(client.getServerUrl());
+    }
+    else
+    {
+        Serial.print("InfluxDB connection failed: ");
+        Serial.println(client.getLastErrorMessage());
+    }
+
+    Wire.begin();
+    scd4x.begin(Wire, SCD41_I2C_ADDR_62);
+    scd4x.wakeUp();
+    scd4x.stopPeriodicMeasurement();
+    scd4x.reinit();
+    scd4x.startPeriodicMeasurement();
+}
+
+void loop()
+{
+    static unsigned long lastMeasurementMs = 0;
+    unsigned long now = millis();
+    if (now - lastMeasurementMs < measurementSleepMs)
+    {
+        return;
+    }
+    lastMeasurementMs = now;
+
+    bool scdReady = false;
+    uint16_t co2 = 0;
+    float temperature = 0.0f;
+    float humidity = 0.0f;
+
+    int16_t err = scd4x.getDataReadyStatus(scdReady);
+    if (err == 0 && scdReady)
+    {
+        err = scd4x.readMeasurement(co2, temperature, humidity);
+        if (err == 0)
+        {
+            Serial.printf("CO2: %u ppm\n", co2);
+            Serial.printf("Temperature: %.2f C\n", temperature);
+            Serial.printf("Humidity: %.2f %%RH\n", humidity);
+
+            sensorPoint.clearFields();
+            sensorPoint.addField("co2", co2);
+            sensorPoint.addField("temperature", temperature);
+            sensorPoint.addField("humidity", humidity);
+            sensorPoint.setTime();
+
+            Serial.print("Writing to InfluxDB: ");
+            Serial.println(client.pointToLineProtocol(sensorPoint));
+            if (WiFi.status() != WL_CONNECTED)
+            {
+                Serial.println("WiFi connection lost");
+            }
+            if (!client.writePoint(sensorPoint))
+            {
+                Serial.print("InfluxDB write failed: ");
+                Serial.println(client.getLastErrorMessage());
+            }
+        }
+        else
+        {
+            Serial.println("Error reading SCD41 measurement");
+        }
+    }
+    else if (err != 0)
+    {
+        Serial.println("Error checking SCD41 data ready status");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `co2only` environment in `platformio.ini`
- provide a new `src_co2/main.cpp` sketch that only sends SCD41 data
- document how to choose between the full and CO2-only builds in the README

## Testing
- `platformio run -e esp32dev`
- `platformio run -e co2only`


------
https://chatgpt.com/codex/tasks/task_e_684e667135cc8332befbbfea332d2fcc