### PR TITLE
Add SCD41 calibration firmware and rename main env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Getting started with this library is straightforward:
    (you can also adjust `SENSOR_SLEEP_MS` here to set the non-blocking interval
    between readings)
 2. Choose the firmware variant:
-   - `esp32dev` builds the full OPC-N3 and SCD41 firmware located in `src/`.
+   - `full` builds the OPC-N3 and SCD41 firmware located in `src/`.
    - `co2only` builds the CO₂-only firmware found in `src_co2/`.
+   - `calibrate_scd41` runs the manual calibration sequence from `src_calibrate/`.
 3. Flash the code to your ESP32
 4. The device will:
     - Automatically connect to your WiFi network

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,6 @@ lib_deps =
 
 [env:co2only]
 extends = env:full
-# Only compile sources from the src_co2 folder located at project root
 src_filter = +<../src_co2> -<*>
 
 [env:calibrate_scd41]

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:esp32dev]
+[env:full]
 platform = espressif32
 board = esp32dev
 framework = arduino
@@ -19,6 +19,10 @@ lib_deps =
         sensirion/Sensirion I2C SCD4x@^1.0.0
 
 [env:co2only]
-extends = env:esp32dev
+extends = env:full
 # Only compile sources from the src_co2 folder located at project root
 src_filter = +<../src_co2> -<*>
+
+[env:calibrate_scd41]
+extends = env:full
+src_filter = +<../src_calibrate> -<*>

--- a/src_calibrate/main.cpp
+++ b/src_calibrate/main.cpp
@@ -3,11 +3,16 @@
 #include <SensirionI2cScd4x.h>
 #include "config.h"
 
+// Define the target CO2 concentration for calibration (in ppm)
+const uint16_t CALIBRATION_CO2_PPM = 424;
+
 SensirionI2cScd4x scd4x;
 
-void setup() {
+void setup()
+{
     Serial.begin(115200);
-    while (!Serial);
+    while (!Serial)
+        ;
     Serial.println("\n\nSCD41 Manual Calibration");
 
     Wire.begin();
@@ -17,22 +22,33 @@ void setup() {
     scd4x.reinit();
     scd4x.startPeriodicMeasurement();
 
-    Serial.println("Place the sensor in fresh air. Calibration will start in 60 seconds...");
+    // Inform the user to place the sensor in fresh air for calibration
+    Serial.print("Place the sensor in fresh air (");
+    Serial.print(CALIBRATION_CO2_PPM);
+    Serial.println(" ppm CO2). Calibration will start in 5 minutes...");
 }
 
-void loop() {
+void loop()
+{
     static bool calibrationDone = false;
     static unsigned long startMs = millis();
 
-    if (!calibrationDone && millis() - startMs >= 60000) {
-        Serial.println("Performing forced recalibration to 400 ppm...");
+    if (!calibrationDone && millis() - startMs >= 300000)
+    {
+        // Start forced recalibration using the defined CO2 value
+        Serial.print("Performing forced recalibration to ");
+        Serial.print(CALIBRATION_CO2_PPM);
+        Serial.println(" ppm...");
         scd4x.stopPeriodicMeasurement();
         uint16_t frcCorrection = 0;
-        int16_t err = scd4x.performForcedRecalibration(400, frcCorrection);
-        if (err == 0) {
+        int16_t err = scd4x.performForcedRecalibration(CALIBRATION_CO2_PPM, frcCorrection);
+        if (err == 0)
+        {
             Serial.printf("Calibration successful, correction: %u ppm\n", frcCorrection);
             scd4x.persistSettings();
-        } else {
+        }
+        else
+        {
             Serial.printf("Calibration failed, error: %d\n", err);
         }
         scd4x.startPeriodicMeasurement();

--- a/src_calibrate/main.cpp
+++ b/src_calibrate/main.cpp
@@ -1,0 +1,42 @@
+#include <Arduino.h>
+#include <Wire.h>
+#include <SensirionI2cScd4x.h>
+#include "config.h"
+
+SensirionI2cScd4x scd4x;
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial);
+    Serial.println("\n\nSCD41 Manual Calibration");
+
+    Wire.begin();
+    scd4x.begin(Wire, SCD41_I2C_ADDR_62);
+    scd4x.wakeUp();
+    scd4x.stopPeriodicMeasurement();
+    scd4x.reinit();
+    scd4x.startPeriodicMeasurement();
+
+    Serial.println("Place the sensor in fresh air. Calibration will start in 60 seconds...");
+}
+
+void loop() {
+    static bool calibrationDone = false;
+    static unsigned long startMs = millis();
+
+    if (!calibrationDone && millis() - startMs >= 60000) {
+        Serial.println("Performing forced recalibration to 400 ppm...");
+        scd4x.stopPeriodicMeasurement();
+        uint16_t frcCorrection = 0;
+        int16_t err = scd4x.performForcedRecalibration(400, frcCorrection);
+        if (err == 0) {
+            Serial.printf("Calibration successful, correction: %u ppm\n", frcCorrection);
+            scd4x.persistSettings();
+        } else {
+            Serial.printf("Calibration failed, error: %d\n", err);
+        }
+        scd4x.startPeriodicMeasurement();
+        calibrationDone = true;
+        Serial.println("Calibration finished. Restart device for normal operation.");
+    }
+}


### PR DESCRIPTION
## Summary
- rename default PlatformIO environment to `full`
- add new `calibrate_scd41` environment
- document new options in README
- implement calibration firmware under `src_calibrate`

## Testing
- `platformio run -e full`
- `platformio run -e co2only`
- `platformio run -e calibrate_scd41`


------
https://chatgpt.com/codex/tasks/task_e_684e799364248332bddbeb9606fa4be0