### PR TITLE
Ensure valid time before logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Getting started with this library is straightforward:
 
 1. Copy `include/config.h.example` to `include/config.h` and update it with your WiFi and InfluxDB credentials
    (you can also adjust `SENSOR_SLEEP_MS` here to set the non-blocking interval
-   between readings)
-2. The shared `OpcN3` driver resides in `lib/opcn3/`.
-3. Choose the firmware variant:
+   between readings and update `TZ_INFO` if needed)
+2. Ensure the board has internet access so it can synchronize the clock via NTP. Each firmware waits for a valid timestamp before sending data.
+3. The shared `OpcN3` driver resides in `lib/opcn3/`.
+4. Choose the firmware variant:
    - `full` builds the OPC-N3 and SCD41 firmware located in `src/`.
    - `scd41_only` builds the CO₂-only firmware found in `src_co2/`.
    - `opcn3_only` builds only the OPC-N3 firmware in `src_opc_only/`.

--- a/src_calibrate/main.cpp
+++ b/src_calibrate/main.cpp
@@ -5,6 +5,7 @@
 #include <InfluxDbClient.h>
 #include <InfluxDbCloud.h>
 #include "config.h"
+#include <time.h>
 
 // Define the target CO2 concentration for calibration (in ppm)
 const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
@@ -23,6 +24,19 @@ SensirionI2cScd4x scd4x;
 
 InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
 Point sensorPoint("scd41");
+
+static void waitForTimeSync()
+{
+    time_t nowSecs = time(nullptr);
+    Serial.print("Waiting for time sync");
+    while (nowSecs < 1609459200)
+    {
+        Serial.print(".");
+        delay(500);
+        nowSecs = time(nullptr);
+    }
+    Serial.println(" done");
+}
 
 void setup()
 {
@@ -45,6 +59,7 @@ void setup()
     Serial.println(" connected");
 
     timeSync(TZ_INFO, "pool.ntp.org", "time.nis.gov");
+    waitForTimeSync();
 
     client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::S));
     sensorPoint.addTag("device", DEVICE);

--- a/src_co2/main.cpp
+++ b/src_co2/main.cpp
@@ -5,6 +5,7 @@
 #include <InfluxDbClient.h>
 #include <InfluxDbCloud.h>
 #include "config.h"
+#include <time.h>
 
 const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
 
@@ -18,6 +19,19 @@ SensirionI2cScd4x scd4x;
 
 InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
 Point sensorPoint("scd41");
+
+static void waitForTimeSync()
+{
+    time_t nowSecs = time(nullptr);
+    Serial.print("Waiting for time sync");
+    while (nowSecs < 1609459200)
+    {
+        Serial.print(".");
+        delay(500);
+        nowSecs = time(nullptr);
+    }
+    Serial.println(" done");
+}
 
 void setup()
 {
@@ -36,7 +50,9 @@ void setup()
     }
     Serial.println(" connected");
 
+
     timeSync(TZ_INFO, "pool.ntp.org", "time.nis.gov");
+    waitForTimeSync();
 
     client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::S));
     sensorPoint.addTag("device", DEVICE);

--- a/src_opc_only/main.cpp
+++ b/src_opc_only/main.cpp
@@ -5,6 +5,7 @@
 #include <InfluxDbCloud.h>
 #include "OpcN3.h"
 #include "config.h"
+#include <time.h>
 
 // --- Pin Configuration ---
 const int OPC_MOSI_PIN = 23;
@@ -35,6 +36,19 @@ const int MAX_CONSECUTIVE_FAILURES = 5;
 InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
 Point sensorPoint("opc_n3");
 
+static void waitForTimeSync()
+{
+  time_t nowSecs = time(nullptr);
+  Serial.print("Waiting for time sync");
+  while (nowSecs < 1609459200)
+  {
+    Serial.print(".");
+    delay(500);
+    nowSecs = time(nullptr);
+  }
+  Serial.println(" done");
+}
+
 void setup()
 {
   Serial.begin(115200);
@@ -55,6 +69,7 @@ void setup()
 
   // Synchronize time for accurate timestamps
   timeSync(TZ_INFO, "pool.ntp.org", "time.nis.gov");
+  waitForTimeSync();
 
   // Prepare InfluxDB client
   client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::S));


### PR DESCRIPTION
## Summary
- wait for NTP sync in all firmware variants
- document the need for NTP connectivity

## Testing
- `platformio run -e full`


------
https://chatgpt.com/codex/tasks/task_e_684ea0fa997083329d527b336ccf65ff