### PR TITLE
Remove unused sampling period control

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ The library automatically transfers all measurements to InfluxDB via WiFi connec
     - Particle counts for 24 distinct size bins.
     - Particle size boundaries for each bin (in µm).
     - Actual sampling period and sample flow rate.
-    - Status information like laser status and reject counts.
-- **Configurable Sampling Period**: Allows you to programmatically set the sensor's sampling period.
 - **Adjustable Measurement Sleep**: Configure how long the sensor waits between
   readings so that it can collect data over extended periods (e.g., 60 seconds)
   before transmission. The wait uses a non-blocking timer so your code can
@@ -80,7 +78,6 @@ Initializes the sensor. This method performs the full startup sequence:
 2.  Establishes and verifies the SPI connection by reading the firmware version.
 3.  Turns on the fan and laser, with appropriate delays.
 4.  Reads the sensor's configuration, including particle bin boundaries.
-5.  Sets a default sampling period of 1 second.
 - **Returns**: `true` if initialization was successful, `false` otherwise.
 
 #### `bool readData(OpcN3Data &data)`
@@ -88,13 +85,6 @@ Reads the latest histogram data packet from the sensor, validates the CRC, and p
 - **Parameters**:
     - `data`: A reference to an `OpcN3Data` struct where the results will be stored.
 - **Returns**: `true` if data was read and validated successfully, `false` on communication error or CRC mismatch.
-
-#### `bool setSamplingPeriod(float seconds)`
-Sets the active sampling period of the sensor. This modifies the `AMSamplingIntervalCount` configuration variable in the sensor's volatile memory. The change will be reset on power loss.
-- A short delay is introduced after writing the new value so the sensor has time to process the update.
-- **Parameters**:
-    - `seconds`: The desired sampling period in seconds. The recommended range is 1.0 to 30.0.
-- **Returns**: `true` if the configuration was successfully written to the sensor, `false` otherwise.
 
 ### `OpcN3Data` Struct
 

--- a/lib/opcn3/src/OpcN3.h
+++ b/lib/opcn3/src/OpcN3.h
@@ -41,9 +41,6 @@ public:
     // Reads the latest histogram data from the sensor
     bool readData(OpcN3Data &data);
 
-    // NEW: Sets the sampling period in seconds (1 to 30 recommended)
-    bool setSamplingPeriod(float seconds);
-
 private:
     // --- Pin and SPI settings ---
     int _ss_pin;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,10 +22,6 @@ const int OPC_SS_PIN = 5;
 // mechanism is non-blocking so the MCU can perform other tasks.
 const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
 
-// The OPC-N3 sampling period should match the sleep duration so that each
-// reading contains data collected during the entire wait time.
-float samplingPeriod = measurementSleepMs / 1000.0f;
-
 // --- Global Objects ---
 OpcN3 opc(OPC_SS_PIN);
 SensirionI2cScd4x scd4x;
@@ -108,7 +104,6 @@ void setup()
   scd4x.startPeriodicMeasurement();
 
   // Initialize the OPC-N3 sensor
-  // This now includes setting the default sampling period to 1 second
   if (!opc.begin())
   {
     Serial.println("FATAL: OPC-N3 initialization failed. Program halted.");
@@ -116,10 +111,6 @@ void setup()
       ; // Halt execution
   }
 
-  if (!opc.setSamplingPeriod(samplingPeriod))
-  {
-    Serial.println("Warning: Failed to set custom sampling period");
-  }
 }
 
 void loop()

--- a/src_opc_only/main.cpp
+++ b/src_opc_only/main.cpp
@@ -19,10 +19,6 @@ const int OPC_SS_PIN = 5;
 // mechanism is non-blocking so the MCU can perform other tasks.
 const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
 
-// The OPC-N3 sampling period should match the sleep duration so that each
-// reading contains data collected during the entire wait time.
-float samplingPeriod = measurementSleepMs / 1000.0f;
-
 // --- Global Objects ---
 OpcN3 opc(OPC_SS_PIN);
 const int MAX_CONSECUTIVE_FAILURES = 5;
@@ -93,7 +89,6 @@ void setup()
 
 
   // Initialize the OPC-N3 sensor
-  // This now includes setting the default sampling period to 1 second
   if (!opc.begin())
   {
     Serial.println("FATAL: OPC-N3 initialization failed. Program halted.");
@@ -101,10 +96,6 @@ void setup()
       ; // Halt execution
   }
 
-  if (!opc.setSamplingPeriod(samplingPeriod))
-  {
-    Serial.println("Warning: Failed to set custom sampling period");
-  }
 }
 
 void loop()


### PR DESCRIPTION
## Summary
- drop `OpcN3::setSamplingPeriod` API
- remove sampling period calls from example programs
- clean up README references to the removed method

## Testing
- `pio run -e opcn3_only` *(fails: `pio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe12a86c88332b0cc2a6f1f991170