### PR TITLE
Ensure Influx fields show their origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,12 @@ distribution. The table below lists the approximate diameter range for each bin.
 ## InfluxDB Integration
 The example project writes all sensor data directly to an InfluxDB instance.
 In addition to the PM values and environmental measurements, the individual
-particle bin counts are stored as separate fields (`bin_00` to `bin_23`). This
+particle bin counts are stored as separate fields (`opc_bin_00` to `opc_bin_23`). This
 allows detailed analysis and visualization of the histogram data in tools like
 Grafana.
 The CO₂, temperature, and humidity values measured by the SCD41 are also
-included in each InfluxDB point.
+included in each InfluxDB point. All field names are prefixed with their source
+(`opc_`, `scd41_`, or `weather_`) so the origin of every measurement is clear.
 
 ## License
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,35 +190,35 @@ void loop()
 
       // Prepare InfluxDB point
       sensorPoint.clearFields();
-      sensorPoint.addField("pm1", sensorData.pm_a);
-      sensorPoint.addField("pm2_5", sensorData.pm_b);
-      sensorPoint.addField("pm10", sensorData.pm_c);
-      sensorPoint.addField("temperature", sensorData.temperature_c);
-      sensorPoint.addField("humidity", sensorData.humidity_rh);
-      sensorPoint.addField("co2", co2);
-      sensorPoint.addField("scd_temp", scdTemperature);
-      sensorPoint.addField("scd_humidity", scdHumidity);
+      sensorPoint.addField("opc_pm1", sensorData.pm_a);
+      sensorPoint.addField("opc_pm2_5", sensorData.pm_b);
+      sensorPoint.addField("opc_pm10", sensorData.pm_c);
+      sensorPoint.addField("opc_temperature", sensorData.temperature_c);
+      sensorPoint.addField("opc_humidity", sensorData.humidity_rh);
+      sensorPoint.addField("scd41_co2", co2);
+      sensorPoint.addField("scd41_temperature", scdTemperature);
+      sensorPoint.addField("scd41_humidity", scdHumidity);
 
       if (weather.data().valid)
       {
-        sensorPoint.addField("weather_temp", weather.data().temperature_c);
+        sensorPoint.addField("weather_temperature", weather.data().temperature_c);
         sensorPoint.addField("weather_humidity", weather.data().humidity_rh);
-        sensorPoint.addField("weather_apparent", weather.data().apparent_temperature_c);
+        sensorPoint.addField("weather_apparent_temperature", weather.data().apparent_temperature_c);
         sensorPoint.addField("weather_is_day", weather.data().is_day);
         sensorPoint.addField("weather_rain", weather.data().rain_mm);
-        sensorPoint.addField("cloud_cover_pct", weather.data().cloud_cover_pct);
-        sensorPoint.addField("pressure_msl", weather.data().pressure_msl_hpa);
-        sensorPoint.addField("surface_pressure", weather.data().surface_pressure_hpa);
-        sensorPoint.addField("wind_speed_kmh", weather.data().wind_speed_kmh);
-        sensorPoint.addField("wind_dir_deg", weather.data().wind_direction_deg);
-        sensorPoint.addField("wind_gusts_kmh", weather.data().wind_gusts_kmh);
+        sensorPoint.addField("weather_cloud_cover_pct", weather.data().cloud_cover_pct);
+        sensorPoint.addField("weather_pressure_msl", weather.data().pressure_msl_hpa);
+        sensorPoint.addField("weather_surface_pressure", weather.data().surface_pressure_hpa);
+        sensorPoint.addField("weather_wind_speed_kmh", weather.data().wind_speed_kmh);
+        sensorPoint.addField("weather_wind_dir_deg", weather.data().wind_direction_deg);
+        sensorPoint.addField("weather_wind_gusts_kmh", weather.data().wind_gusts_kmh);
       }
 
       // Add individual bin counts as separate fields for detailed analysis
       for (int i = 0; i < 24; i++)
       {
-        char fieldName[8];
-        snprintf(fieldName, sizeof(fieldName), "bin_%02d", i);
+        char fieldName[12];
+        snprintf(fieldName, sizeof(fieldName), "opc_bin_%02d", i);
         sensorPoint.addField(fieldName, (int)sensorData.bin_counts[i]);
       }
 

--- a/src_calibrate/main.cpp
+++ b/src_calibrate/main.cpp
@@ -159,9 +159,9 @@ void loop()
             Serial.printf("Humidity: %.2f %%RH\n", humidity);
 
             sensorPoint.clearFields();
-            sensorPoint.addField("co2", co2);
-            sensorPoint.addField("temperature", temperature);
-            sensorPoint.addField("humidity", humidity);
+            sensorPoint.addField("scd41_co2", co2);
+            sensorPoint.addField("scd41_temperature", temperature);
+            sensorPoint.addField("scd41_humidity", humidity);
             sensorPoint.setTime();
 
             Serial.print("Writing to InfluxDB: ");

--- a/src_co2/main.cpp
+++ b/src_co2/main.cpp
@@ -103,9 +103,9 @@ void loop()
             Serial.printf("Humidity: %.2f %%RH\n", humidity);
 
             sensorPoint.clearFields();
-            sensorPoint.addField("co2", co2);
-            sensorPoint.addField("temperature", temperature);
-            sensorPoint.addField("humidity", humidity);
+            sensorPoint.addField("scd41_co2", co2);
+            sensorPoint.addField("scd41_temperature", temperature);
+            sensorPoint.addField("scd41_humidity", humidity);
             sensorPoint.setTime();
 
             Serial.print("Writing to InfluxDB: ");

--- a/src_opc_only/main.cpp
+++ b/src_opc_only/main.cpp
@@ -148,17 +148,17 @@ void loop()
 
       // Prepare InfluxDB point
       sensorPoint.clearFields();
-      sensorPoint.addField("pm1", sensorData.pm_a);
-      sensorPoint.addField("pm2_5", sensorData.pm_b);
-      sensorPoint.addField("pm10", sensorData.pm_c);
-      sensorPoint.addField("temperature", sensorData.temperature_c);
-      sensorPoint.addField("humidity", sensorData.humidity_rh);
+      sensorPoint.addField("opc_pm1", sensorData.pm_a);
+      sensorPoint.addField("opc_pm2_5", sensorData.pm_b);
+      sensorPoint.addField("opc_pm10", sensorData.pm_c);
+      sensorPoint.addField("opc_temperature", sensorData.temperature_c);
+      sensorPoint.addField("opc_humidity", sensorData.humidity_rh);
 
       // Add individual bin counts as separate fields for detailed analysis
       for (int i = 0; i < 24; i++)
       {
-        char fieldName[8];
-        snprintf(fieldName, sizeof(fieldName), "bin_%02d", i);
+        char fieldName[12];
+        snprintf(fieldName, sizeof(fieldName), "opc_bin_%02d", i);
         sensorPoint.addField(fieldName, (int)sensorData.bin_counts[i]);
       }
 


### PR DESCRIPTION
## Summary
- add `opc_`, `scd41_` and `weather_` prefixes to all InfluxDB fields
- document field prefixes in the readme

## Testing
- `pio run -e full` *(fails: SENSOR_SLEEP_MS not declared)*

------
https://chatgpt.com/codex/tasks/task_e_684febbad15083328173c21d5b5006af