### PR TITLE
Add derived pollen and CO₂ metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The library automatically transfers all measurements to InfluxDB via WiFi connec
 - **Clear Serial Output**: Provides detailed, human-readable logs for initialization, measurements, and error conditions.
 - **Integrated CO₂ Measurements**: Reads CO₂ concentration, temperature, and humidity from an attached SCD41 sensor via I²C.
 - **Weather API Support**: Retrieves current weather conditions from the Open-Meteo service and stores them in InfluxDB.
+- **Derived Metrics**: Calculates pollen load and CO₂ air quality from sensor data and writes them to InfluxDB using the `calc_` prefix.
 
 ## Hardware Requirements
 
@@ -140,6 +141,16 @@ distribution. The table below lists the approximate diameter range for each bin.
 | 22 | 31.000 – 34.000 |
 | 23 | 34.000 – 37.000 |
 | 24 | 37.000 – 40.000 |
+
+### Derived Metrics
+
+The firmware calculates additional values on the device:
+
+- **Pollen count**: sum of histogram bins 13–24 (particles roughly 10–40 µm).
+- **Pollen level**: qualitative state derived from the count (`very_low`, `low`, `moderate`, `high`, `very_high`).
+- **CO₂ quality**: classification of indoor air quality based on measured CO₂ (`excellent`, `good`, `fair`, `poor`, `very_poor`).
+
+All derived fields are written to InfluxDB with the `calc_` prefix.
 
 ## Troubleshooting
 

--- a/src/DerivedMetrics.h
+++ b/src/DerivedMetrics.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "OpcN3.h"
+
+inline uint32_t calculatePollenCount(const OpcN3Data &data)
+{
+    uint32_t count = 0;
+    for (int i = 12; i < 24; ++i) // bins 13-24 correspond to ~10-40 um
+    {
+        count += data.bin_counts[i];
+    }
+    return count;
+}
+
+inline const char *classifyPollenLevel(uint32_t pollenCount)
+{
+    if (pollenCount < 100)
+        return "very_low";
+    else if (pollenCount < 300)
+        return "low";
+    else if (pollenCount < 700)
+        return "moderate";
+    else if (pollenCount < 1200)
+        return "high";
+    else
+        return "very_high";
+}
+
+inline const char *classifyCo2Quality(uint16_t co2ppm)
+{
+    if (co2ppm < 800)
+        return "excellent";
+    else if (co2ppm < 1000)
+        return "good";
+    else if (co2ppm < 1500)
+        return "fair";
+    else if (co2ppm < 2000)
+        return "poor";
+    else
+        return "very_poor";
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "OpcN3.h"
 #include "config.h"
 #include "WeatherClient.h"
+#include "DerivedMetrics.h"
 #include <time.h>
 
 // --- Pin Configuration ---
@@ -187,6 +188,14 @@ void loop()
                       sensorData.bin_counts[i]);
       }
 
+      // Derived metrics
+      uint32_t pollenCount = calculatePollenCount(sensorData);
+      const char *pollenLevel = classifyPollenLevel(pollenCount);
+      const char *co2Quality = classifyCo2Quality(co2);
+      Serial.printf("Pollen count: %u\n", pollenCount);
+      Serial.printf("Pollen level: %s\n", pollenLevel);
+      Serial.printf("CO2 quality: %s\n", co2Quality);
+
       // Prepare InfluxDB point
       sensorPoint.clearFields();
       sensorPoint.addField("opc_pm1", sensorData.pm_a);
@@ -197,6 +206,9 @@ void loop()
       sensorPoint.addField("scd41_co2", co2);
       sensorPoint.addField("scd41_temperature", scdTemperature);
       sensorPoint.addField("scd41_humidity", scdHumidity);
+      sensorPoint.addField("calc_pollen_count", (int)pollenCount);
+      sensorPoint.addField("calc_pollen_level", pollenLevel);
+      sensorPoint.addField("calc_co2_quality", co2Quality);
 
       if (weather.data().valid)
       {


### PR DESCRIPTION
## Summary
- compute pollen and CO₂ quality values directly on the ESP32
- include new calculation helper `DerivedMetrics.h`
- record these values in InfluxDB with a `calc_` prefix
- document the derived metrics in the README

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fef30cb8c833292edbc0ebc025a98