### PR TITLE
Fix ESP32 UART build

### DIFF
--- a/lib/SparkFun Toolkit/src/sfTkArdUART.cpp
+++ b/lib/SparkFun Toolkit/src/sfTkArdUART.cpp
@@ -193,7 +193,7 @@ sfTkError_t sfTkArdUART::_start(void)
     if (_running)
         end(); // close the port if already running
     // set the config
-#ifdef ARDUINO_ARCH_ESP8266
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
     // ESP8266 does not support setting stop bits, parity, and data bits in a stanard manner.
     _hwSerial->begin(_config.baudRate);
 #else
@@ -334,7 +334,7 @@ bool sfTkArdUART::findUntil(CONSTVAR uint8_t *target, size_t targetLen, CONSTVAR
     return _hwSerial->findUntil(target, targetLen, terminate, termLen);
 }
 
-#ifdef ARDUINO_ARCH_ESP8266
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
 long sfTkArdUART::parseInt()
 {
     if (!_hwSerial)

--- a/lib/SparkFun Toolkit/src/sfTkArdUART.h
+++ b/lib/SparkFun Toolkit/src/sfTkArdUART.h
@@ -259,7 +259,7 @@ class sfTkArdUART : public sfTkIUART
     bool findUntil(CONSTVAR char *target, size_t targetLen, CONSTVAR char *terminate, size_t termLen);
     bool findUntil(CONSTVAR uint8_t *target, size_t targetLen, CONSTVAR char *terminate, size_t termLen);
 
-#ifdef ARDUINO_ARCH_ESP8266
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
     long parseInt();
     float parseFloat();
 #else


### PR DESCRIPTION
## Summary
- fix UART parse function declarations for ESP32 by reusing ESP8266 path
- ensure compile uses old API when building on ESP32

## Testing
- `platformio run -e opcn3_bmv080` *(fails: SENSOR_SLEEP_MS and other defines missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860643d51f08332991e2d272af605d5