### PR TITLE
Add BMV080 PM-only firmware variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Getting started with this library is straightforward:
    - `full` builds the OPC-N3 and SCD41 firmware located in `src/`.
    - `scd41_only` builds the CO₂-only firmware found in `src_co2/`.
    - `opcn3_only` builds only the OPC-N3 firmware in `src_opc_only/`.
+   - `bmv080_pm_only` builds the OPC-N3 firmware that writes only PM1.0, PM2.5, and PM10 values in `src_bmv080/`.
    - `calibrate_scd41` performs a manual SCD41 calibration and then continues
      sending measurements to InfluxDB (code in `src_calibrate/`).
 4. Flash the code to your ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,3 +30,6 @@ build_src_filter = +<../src_calibrate> -<*>
 [env:opcn3_only]
 extends = env:full
 build_src_filter = +<../src_opc_only> -<*>
+[env:bmv080_pm_only]
+extends = env:full
+build_src_filter = +<../src_bmv080> -<*>

--- a/src_bmv080/main.cpp
+++ b/src_bmv080/main.cpp
@@ -1,0 +1,172 @@
+#include <Arduino.h>
+#include <SPI.h>
+#include <WiFi.h>
+#include <InfluxDbClient.h>
+#include <InfluxDbCloud.h>
+#include "OpcN3.h"
+#include "config.h"
+#include <time.h>
+
+// --- Pin Configuration ---
+const int OPC_MOSI_PIN = 23;
+const int OPC_MISO_PIN = 19;
+const int OPC_SCK_PIN = 18;
+const int OPC_SS_PIN = 5;
+
+// --- Sampling Period & Sleep Configuration ---
+// Duration to wait between sensor readings (in milliseconds). Adjust this to
+// control how long the OPC-N3 collects data before the next read. The waiting
+// mechanism is non-blocking so the MCU can perform other tasks.
+const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
+
+// --- Global Objects ---
+OpcN3 opc(OPC_SS_PIN);
+const int MAX_CONSECUTIVE_FAILURES = 5;
+
+#if defined(ESP32)
+#define DEVICE "ESP32"
+#else
+#define DEVICE "ARDUINO"
+#endif
+
+InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
+Point sensorPoint("opc_n3");
+
+static void waitForTimeSync()
+{
+  time_t nowSecs = time(nullptr);
+  Serial.print("Waiting for time sync");
+  while (nowSecs < 1609459200)
+  {
+    Serial.print(".");
+    delay(500);
+    nowSecs = time(nullptr);
+  }
+  Serial.println(" done");
+}
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial)
+    ;
+  Serial.println("\n\nOPC-N3 Sensor Reader - Structured Version");
+
+  // Connect to WiFi
+  Serial.printf("Connecting to WiFi '%s'", WIFI_SSID);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    Serial.print(".");
+    delay(500);
+  }
+  Serial.println(" connected");
+
+  // Synchronize time for accurate timestamps
+  timeSync(TZ_INFO, "pool.ntp.org", "time.nis.gov");
+  waitForTimeSync();
+
+  // Prepare InfluxDB client
+  client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::S));
+  sensorPoint.addTag("device", DEVICE);
+  sensorPoint.addTag("ssid", WiFi.SSID());
+
+  if (client.validateConnection())
+  {
+    Serial.print("Connected to InfluxDB: ");
+    Serial.println(client.getServerUrl());
+  }
+  else
+  {
+    Serial.print("InfluxDB connection failed: ");
+    Serial.println(client.getLastErrorMessage());
+  }
+
+  // Initialize SPI bus
+  SPI.begin(OPC_SCK_PIN, OPC_MISO_PIN, OPC_MOSI_PIN, OPC_SS_PIN);
+
+
+
+  // Initialize the OPC-N3 sensor
+  if (!opc.begin())
+  {
+    Serial.println("FATAL: OPC-N3 initialization failed. Program halted.");
+    while (1)
+      ; // Halt execution
+  }
+
+}
+
+void loop()
+{
+  static int consecutive_failures = 0;
+  static bool discard_next_success = true; // discard first valid reading
+  static unsigned long lastMeasurementMs = 0;
+
+  unsigned long now = millis();
+  if (now - lastMeasurementMs < measurementSleepMs)
+  {
+    return; // wait until the next measurement interval without blocking
+  }
+  lastMeasurementMs = now;
+
+  Serial.println("\n--- Requesting New Measurement ---");
+
+  OpcN3Data sensorData;
+  if (opc.readData(sensorData))
+  {
+    consecutive_failures = 0; // Reset counter on success
+
+    if (discard_next_success)
+    {
+      Serial.println("First valid measurement discarded as per datasheet recommendation.");
+      discard_next_success = false;
+    }
+    else
+    {
+      Serial.println("Data successfully read and validated.");
+      Serial.printf("Temperature: %.2f C\n", sensorData.temperature_c);
+      Serial.printf("Humidity: %.2f %%RH\n", sensorData.humidity_rh);
+
+      Serial.printf("PM1: %.2f ug/m3\n", sensorData.pm_a);
+      Serial.printf("PM2.5: %.2f ug/m3\n", sensorData.pm_b);
+      Serial.printf("PM10: %.2f ug/m3\n", sensorData.pm_c);
+      Serial.printf("Actual Sampling Period: %.2f s\n", sensorData.sampling_period_s); // Verify the period
+      Serial.printf("Checksum: OK (Received: 0x%04X)\n", sensorData.received_checksum);
+
+      sensorPoint.clearFields();
+      sensorPoint.addField("opc_pm1", sensorData.pm_a);
+      sensorPoint.addField("opc_pm2_5", sensorData.pm_b);
+      sensorPoint.addField("opc_pm10", sensorData.pm_c);
+
+      sensorPoint.setTime();
+
+      Serial.print("Writing to InfluxDB: ");
+      Serial.println(client.pointToLineProtocol(sensorPoint));
+      if (WiFi.status() != WL_CONNECTED)
+      {
+        Serial.println("WiFi connection lost");
+      }
+      if (!client.writePoint(sensorPoint))
+      {
+        Serial.print("InfluxDB write failed: ");
+        Serial.println(client.getLastErrorMessage());
+      }
+    }
+  }
+  else
+  {
+    consecutive_failures++;
+    discard_next_success = true; // discard next successful measurement after a failure
+    Serial.printf("Measurement failed. This is failure #%d in a row.\n", consecutive_failures);
+
+    if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES)
+    {
+      Serial.println("WARNING: Multiple consecutive measurements failed. The sensor might have an issue or the connection is unstable.");
+    }
+
+    // Wait for recovery on failure
+    delay(2500);
+  }
+}


### PR DESCRIPTION
## Summary
- add new firmware variant `bmv080_pm_only` that only sends PM1, PM2.5 and PM10 values
- document the new build environment in `README.md`
- include the new environment in `platformio.ini`

## Testing
- `pio run -e bmv080_pm_only` *(fails: config values not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686105c4c3648332b4dab2f4c24a692c