### PR TITLE
Add BMV080-only firmware skeleton

### DIFF
--- a/lib/bmv080/README
+++ b/lib/bmv080/README
@@ -1,0 +1,1 @@
+Stub BMV080 sensor driver providing dummy values.

--- a/lib/bmv080/src/Bmv080.cpp
+++ b/lib/bmv080/src/Bmv080.cpp
@@ -1,0 +1,14 @@
+#include "Bmv080.h"
+
+bool Bmv080::begin() {
+    // Stub initialization
+    return true;
+}
+
+bool Bmv080::readData(Bmv080Data &data) {
+    // Return dummy data for now
+    data.temperature_c = 25.0f;
+    data.humidity_rh = 50.0f;
+    data.pressure_pa = 101325.0f;
+    return true;
+}

--- a/lib/bmv080/src/Bmv080.h
+++ b/lib/bmv080/src/Bmv080.h
@@ -1,0 +1,14 @@
+#ifndef BMV080_H
+#define BMV080_H
+#include <Arduino.h>
+struct Bmv080Data {
+    float temperature_c;
+    float humidity_rh;
+    float pressure_pa;
+};
+class Bmv080 {
+public:
+    bool begin();
+    bool readData(Bmv080Data &data);
+};
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,3 +30,7 @@ build_src_filter = +<../src_calibrate> -<*>
 [env:opcn3_only]
 extends = env:full
 build_src_filter = +<../src_opc_only> -<*>
+
+[env:bmv080_only]
+extends = env:full
+build_src_filter = +<../src_bmv080> -<*>

--- a/src_bmv080/README.md
+++ b/src_bmv080/README.md
@@ -1,0 +1,1 @@
+This firmware variant reads data from the BMV080 sensor only and writes measurements to InfluxDB. Values are generated from a stub driver for demonstration purposes.

--- a/src_bmv080/main.cpp
+++ b/src_bmv080/main.cpp
@@ -1,0 +1,115 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <InfluxDbClient.h>
+#include <InfluxDbCloud.h>
+#include "config.h"
+#include <time.h>
+#include "Bmv080.h"
+
+const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
+
+Bmv080 bmv;
+
+#if defined(ESP32)
+#define DEVICE "ESP32"
+#else
+#define DEVICE "ARDUINO"
+#endif
+
+InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
+Point sensorPoint("bmv080");
+
+static void waitForTimeSync()
+{
+    time_t nowSecs = time(nullptr);
+    Serial.print("Waiting for time sync");
+    while (nowSecs < 1609459200)
+    {
+        Serial.print(".");
+        delay(500);
+        nowSecs = time(nullptr);
+    }
+    Serial.println(" done");
+}
+
+void setup()
+{
+    Serial.begin(115200);
+    while (!Serial)
+        ;
+    Serial.println("\n\nBMV080 Reader");
+
+    Serial.printf("Connecting to WiFi '%s'", WIFI_SSID);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        Serial.print(".");
+        delay(500);
+    }
+    Serial.println(" connected");
+
+    timeSync(TZ_INFO, "pool.ntp.org", "time.nis.gov");
+    waitForTimeSync();
+
+    client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::S));
+    sensorPoint.addTag("device", DEVICE);
+    sensorPoint.addTag("ssid", WiFi.SSID());
+
+    if (client.validateConnection())
+    {
+        Serial.print("Connected to InfluxDB: ");
+        Serial.println(client.getServerUrl());
+    }
+    else
+    {
+        Serial.print("InfluxDB connection failed: ");
+        Serial.println(client.getLastErrorMessage());
+    }
+
+    if (!bmv.begin()) {
+        Serial.println("Failed to initialize BMV080 sensor");
+    }
+}
+
+void loop()
+{
+    static unsigned long lastMeasurementMs = 0;
+    unsigned long now = millis();
+    if (now - lastMeasurementMs < measurementSleepMs)
+    {
+        return;
+    }
+    lastMeasurementMs = now;
+
+    Bmv080Data data;
+    if (bmv.readData(data))
+    {
+        Serial.printf("Temperature: %.2f C\n", data.temperature_c);
+        Serial.printf("Humidity: %.2f %%RH\n", data.humidity_rh);
+        Serial.printf("Pressure: %.2f Pa\n", data.pressure_pa);
+
+        sensorPoint.clearFields();
+        sensorPoint.addField("bmv080_temperature", data.temperature_c);
+        sensorPoint.addField("bmv080_humidity", data.humidity_rh);
+        sensorPoint.addField("bmv080_pressure", data.pressure_pa);
+        sensorPoint.setTime();
+
+        Serial.print("Writing to InfluxDB: ");
+        Serial.println(client.pointToLineProtocol(sensorPoint));
+        if (WiFi.status() != WL_CONNECTED)
+        {
+            Serial.println("WiFi connection lost");
+        }
+        if (!client.writePoint(sensorPoint))
+        {
+            Serial.print("InfluxDB write failed: ");
+            Serial.println(client.getLastErrorMessage());
+        }
+    }
+    else
+    {
+        Serial.println("Error reading BMV080 measurement");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a placeholder BMV080 library with dummy data
- provide a new firmware variant under `src_bmv080`
- expose `bmv080_only` build environment in `platformio.ini`

## Testing
- `pio run -e bmv080_only` *(fails: SENSOR_SLEEP_MS not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68610896ea7c83329c2df4582ac9c9c3