### PR TITLE
Add BMV080 sensor environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Getting started with this library is straightforward:
    - `full` builds the OPC-N3 and SCD41 firmware located in `src/`.
    - `scd41_only` builds the CO₂-only firmware found in `src_co2/`.
    - `opcn3_only` builds only the OPC-N3 firmware in `src_opc_only/`.
+   - `bmv080_only` builds only the BMV080 firmware located in `src_bmv080/`.
    - `calibrate_scd41` performs a manual SCD41 calibration and then continues
      sending measurements to InfluxDB (code in `src_calibrate/`).
 4. Flash the code to your ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,3 +30,7 @@ build_src_filter = +<../src_calibrate> -<*>
 [env:opcn3_only]
 extends = env:full
 build_src_filter = +<../src_opc_only> -<*>
+
+[env:bmv080_only]
+extends = env:full
+build_src_filter = +<../src_bmv080> -<*>

--- a/src_bmv080/main.cpp
+++ b/src_bmv080/main.cpp
@@ -1,0 +1,139 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <Wire.h>
+#include "SparkFun_BMV080_Arduino_Library.h"
+#include <InfluxDbClient.h>
+#include <InfluxDbCloud.h>
+#include "config.h"
+#include <time.h>
+
+const unsigned long measurementSleepMs = SENSOR_SLEEP_MS;
+
+SparkFunBMV080 bmv080;
+
+#if defined(ESP32)
+#define DEVICE "ESP32"
+#else
+#define DEVICE "ARDUINO"
+#endif
+
+InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
+Point sensorPoint("bmv080");
+
+static void waitForTimeSync()
+{
+    time_t nowSecs = time(nullptr);
+    Serial.print("Waiting for time sync");
+    while (nowSecs < 1609459200)
+    {
+        Serial.print(".");
+        delay(500);
+        nowSecs = time(nullptr);
+    }
+    Serial.println(" done");
+}
+
+void setup()
+{
+    Serial.begin(115200);
+    while (!Serial)
+        ;
+    Serial.println("\n\nBMV080 Reader");
+
+    Serial.printf("Connecting to WiFi '%s'", WIFI_SSID);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        Serial.print(".");
+        delay(500);
+    }
+    Serial.println(" connected");
+
+    timeSync(TZ_INFO, "pool.ntp.org", "time.nis.gov");
+    waitForTimeSync();
+
+    client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::S));
+    sensorPoint.addTag("device", DEVICE);
+    sensorPoint.addTag("ssid", WiFi.SSID());
+
+    if (client.validateConnection())
+    {
+        Serial.print("Connected to InfluxDB: ");
+        Serial.println(client.getServerUrl());
+    }
+    else
+    {
+        Serial.print("InfluxDB connection failed: ");
+        Serial.println(client.getLastErrorMessage());
+    }
+
+    Wire.begin();
+    if (!bmv080.begin(SF_BMV080_DEFAULT_ADDRESS, Wire))
+    {
+        Serial.println("BMV080 not detected. Check wiring.");
+        while (1)
+            ;
+    }
+    Serial.println("BMV080 found!");
+
+    bmv080.init();
+    if (bmv080.setMode(SF_BMV080_MODE_CONTINUOUS))
+    {
+        Serial.println("BMV080 set to continuous mode");
+    }
+    else
+    {
+        Serial.println("Error setting BMV080 mode");
+    }
+}
+
+void loop()
+{
+    static unsigned long lastMeasurementMs = 0;
+    unsigned long now = millis();
+    if (now - lastMeasurementMs < measurementSleepMs)
+    {
+        return;
+    }
+    lastMeasurementMs = now;
+
+    if (bmv080.readSensor())
+    {
+        float pm1 = bmv080.PM1();
+        float pm25 = bmv080.PM25();
+        float pm10 = bmv080.PM10();
+        bool obstructed = bmv080.isObstructed();
+
+        Serial.printf("PM1: %.2f \tPM2.5: %.2f \tPM10: %.2f", pm1, pm25, pm10);
+        if (obstructed)
+        {
+            Serial.print("\tObstructed");
+        }
+        Serial.println();
+
+        sensorPoint.clearFields();
+        sensorPoint.addField("bmv_pm1", pm1);
+        sensorPoint.addField("bmv_pm2_5", pm25);
+        sensorPoint.addField("bmv_pm10", pm10);
+        sensorPoint.addField("bmv_obstructed", obstructed ? 1 : 0);
+        sensorPoint.setTime();
+
+        Serial.print("Writing to InfluxDB: ");
+        Serial.println(client.pointToLineProtocol(sensorPoint));
+        if (WiFi.status() != WL_CONNECTED)
+        {
+            Serial.println("WiFi connection lost");
+        }
+        if (!client.writePoint(sensorPoint))
+        {
+            Serial.print("InfluxDB write failed: ");
+            Serial.println(client.getLastErrorMessage());
+        }
+    }
+    else
+    {
+        Serial.println("Error reading BMV080 measurement");
+    }
+}
+

--- a/src_bmv080/main.cpp
+++ b/src_bmv080/main.cpp
@@ -98,7 +98,18 @@ void loop()
     }
     lastMeasurementMs = now;
 
-    if (bmv080.readSensor())
+    bool success = false;
+    for (int i = 0; i < 20; ++i)
+    {
+        if (bmv080.readSensor())
+        {
+            success = true;
+            break;
+        }
+        delay(100); // allow sensor to update
+    }
+
+    if (success)
     {
         float pm1 = bmv080.PM1();
         float pm25 = bmv080.PM25();


### PR DESCRIPTION
## Summary
- add new `bmv080_only` environment in `platformio.ini`
- provide dedicated source to read the SparkFun BMV080 sensor and write data to InfluxDB

## Testing
- `platformio run -e bmv080_only` *(fails: missing `config.h` for WiFi and InfluxDB settings)*

------
https://chatgpt.com/codex/tasks/task_e_68610c6075d4833287767b0effa9d23b